### PR TITLE
Add USSD, data, and voice examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Function-calling with Python and ollama. We are going to use the Africa's Talking API to send airtime and messages to a phone number using Natural language. Thus, creating an generative ai agent. Here are examples of prompts you can use to send airtime to a phone number:
 - Send airtime to xxxxxxxxx2046 and xxxxxxxxx3524 with an amount of 10 in currency KES
 - Send a message to xxxxxxxxx2046 and xxxxxxxxx3524 with a message "Hello, how are you?", using the username "username".
+- Dial a USSD code like *123# on xxxxxxxxx2046
+- Send 500MB of data to xxxxxxxxx2046 on provider safaricom
+- Call xxxxxxxxx2046 from +254700000001
 
 NB: The phone numbers are placeholders for the actual phone numbers.
 You need some VRAM to run this project. You can get VRAM from [here](https://vast.ai/) or [here](https://runpod.io?ref=46wgtjpg)

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -11,7 +11,15 @@ import re
 import pytest
 import pytest_asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
-from utils.function_call import send_airtime, send_message, search_news, translate_text
+from utils.function_call import (
+    send_airtime,
+    send_message,
+    search_news,
+    translate_text,
+    send_ussd,
+    send_mobile_data,
+    make_voice_call,
+)
 
 # Load environment variables: TEST_PHONE_NUMBER
 PHONE_NUMBER = os.getenv("TEST_PHONE_NUMBER")
@@ -190,3 +198,27 @@ async def test_translate_text_special_chars():
     with pytest.raises(ValueError) as exc:
         await translate_text("@#$%^", "French")
     assert "Invalid input" in str(exc.value)
+
+
+@patch("utils.function_call.africastalking.USSD")
+def test_send_ussd_success(mock_ussd):
+    """Test the send_ussd function for a successful USSD request."""
+    mock_ussd.send.return_value = {"Status": "Success"}
+    result = send_ussd(PHONE_NUMBER, "*123#")
+    assert re.search(r"Success", str(result))
+
+
+@patch("utils.function_call.africastalking.MobileData")
+def test_send_mobile_data_success(mock_data):
+    """Test the send_mobile_data function for a successful bundle purchase."""
+    mock_data.send.return_value = {"status": "Success"}
+    result = send_mobile_data(PHONE_NUMBER, "500MB", "safaricom", "daily")
+    assert re.search(r"Success", str(result))
+
+
+@patch("utils.function_call.africastalking.Voice")
+def test_make_voice_call_success(mock_voice):
+    """Test the make_voice_call function for successful call initiation."""
+    mock_voice.call.return_value = {"status": "Queued"}
+    result = make_voice_call("+254700000001", PHONE_NUMBER)
+    assert re.search(r"Queued", str(result))


### PR DESCRIPTION
## Summary
- add USSD, mobile data and voice call utilities
- integrate new tools in the chat workflow
- extend unit tests for new utilities
- show example prompts for USSD, data and voice in README

## Testing
- `make test` *(fails: `.venv/bin/activate` not found)*
- `pytest -q tests/test_cases.py` *(fails: `ModuleNotFoundError: No module named 'pytest_asyncio'`)*

------
https://chatgpt.com/codex/tasks/task_e_684811ea6604832a9b5ea6f0eeadcd2e