### PR TITLE
Fix badge typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Agent Continuous Integration/Continuos Delivery](https://github.com/Shuyib/tool_calling_api/actions/workflows/python-app.yml/badge.svg)](https://github.com/Shuyib/tool_calling_api/blob/main/.github/workflows/python-app.yml)
+[![Agent Continuous Integration/Continuous Delivery](https://github.com/Shuyib/tool_calling_api/actions/workflows/python-app.yml/badge.svg)](https://github.com/Shuyib/tool_calling_api/blob/main/.github/workflows/python-app.yml)
 # Exploring function calling 🗣️ 🤖 🔉 with Python and ollama 🦙
 Function-calling with Python and ollama. We are going to use the Africa's Talking API to send airtime and messages to a phone number using Natural language. Thus, creating an generative ai agent. Here are examples of prompts you can use to send airtime to a phone number:
 - Send airtime to xxxxxxxxx2046 and xxxxxxxxx3524 with an amount of 10 in currency KES


### PR DESCRIPTION
## Summary
- fix `Continuous Delivery` badge text in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6848137457d8832a86caa04cc0f3e171